### PR TITLE
Added RegisterServices option to Install-ContainerTools function

### DIFF
--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -136,6 +136,12 @@ function Initialize-NatNetwork {
     )
 
     begin {
+        # Check of NAT exists
+        $natInfo = Get-HnsNetwork -ErrorAction Ignore | Where-Object { $_.Name -eq $networkName }
+        if ($null -ne $natInfo) {
+            Throw "$networkName already exists. To view existing networks, use `Get-HnsNetwork`. To remove the existing network use the `Remove-HNSNetwork` command."
+        }
+        
         if (!$WinCNIPath) {
             $ContainerdPath = Get-DefaultInstallPath -Tool "containerd"
             $WinCNIPath = "$ContainerdPath\cni"
@@ -178,12 +184,6 @@ function Initialize-NatNetwork {
             }
             catch {
                 Throw "Could not import HNS module. $_"
-            }
-
-            # Check of NAT exists
-            $natInfo = Get-HnsNetwork -ErrorAction Ignore | Where-Object { $_.Name -eq $networkName }
-            if ($null -ne $natInfo) {
-                Throw "$networkName already exists. To view existing networks, use `Get-HnsNetwork`. To remove the existing network use the `Remove-HNSNetwork` command."
             }
 
             # Set default gateway if gateway us null and generate subnet mash=k from Gateway

--- a/containers-toolkit/en-US/containers-toolkit-help.xml
+++ b/containers-toolkit/en-US/containers-toolkit-help.xml
@@ -1086,6 +1086,17 @@
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>RegisterServices</maml:name>
+          <maml:description>
+            <maml:para>Register and Start Conatinerd and Buildkitd services and set up NAT network.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>WhatIf</maml:name>
           <maml:description>
             <maml:para>Shows what would happen if the cmdlet runs. The cmdlet isn't run.</maml:para>
@@ -1171,6 +1182,18 @@
         <maml:name>Force</maml:name>
         <maml:description>
           <maml:para>Force container tools uninstallation (if it exists) without any confirmation prompts</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>RegisterServices</maml:name>
+        <maml:description>
+          <maml:para>Register and Start Conatinerd and Buildkitd services and set up NAT network.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/docs/About/Install-ContainerTools.md
+++ b/docs/About/Install-ContainerTools.md
@@ -15,7 +15,7 @@ Downloads and installs container tool (Containerd, BuildKit, and nerdctl).
 
 ```
 Install-ContainerTools [[-ContainerDVersion] <String>] [[-BuildKitVersion] <String>]
- [[-NerdCTLVersion] <String>] [[-InstallPath] <String>] [[-DownloadPath] <String>] [-CleanUp] [-Force]
+ [[-NerdCTLVersion] <String>] [[-InstallPath] <String>] [[-DownloadPath] <String>] [-CleanUp] [-Force] [-RegisterServices]
  [-Confirm] [-WhatIf] [<CommonParameters>]
 ```
 
@@ -47,6 +47,14 @@ Deletes downloaded files after installation is complete to save on disk space.
 
 ```powershell
 PS C:\> Install-ContainerTools -Cleanup
+```
+
+### Example 4: Register and Start Conatinerd and Buildkitd services and set up NAT network
+
+Register and Start Conatinerd and Buildkitd services and set up NAT network
+
+```powershell
+PS C:\> Install-ContainerTools -RegisterServices
 ```
 
 ## PARAMETERS
@@ -137,6 +145,22 @@ Accept wildcard characters: False
 ### -Force
 
 Force install the tools even if they already exists at the specified path.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RegisterServices
+
+Register and Start Conatinerd and Buildkitd services and set up NAT network.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -62,6 +62,7 @@ Downloads container tool (Containerd, BuildKit, nerdctl) asynchronously and inst
 | DownloadPath | String | Path to download container tools  | `$HOME\Downloads` |
 | Cleanup | Switch | Specifies whether to cleanup after installation is done  |  |
 | Force | Switch | Force install the tools even if they already exists at the specified path |  |
+| RegisterServices | Switch | Register and Start Conatinerd and Buildkitd services and set up NAT network |  |
 | Confirm | Switch | Prompts for confirmation before running the cmdlet. For more information, see the following articles: [about_Preference_Variables](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.4#confirmpreference) and [about_Functions_CmdletBindingAttribute](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-7.4#confirmimpact) |  |
 | WhatIf | Switch | Shows what would happen if the cmdlet runs. The cmdlet isn't run. |  |
 


### PR DESCRIPTION
Adding RegisterServices option in the Install-ContainerTools function introduces the ability to register and start containerd and buildkit services.

when you run Install-ContainerTools -RegisterServices above mentioned services should get registered and start.
![image](https://github.com/microsoft/containers-toolkit/assets/13621263/0f94076a-80fb-4954-91a1-350f0a741aa8)
