### PR TITLE
Update README.md to avoid paths duplication in PSModulePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cd <module path>
 git clone https://github.com/microsoft/containers-toolkit.git
 
 
-$env:PSModulePath += "$env:PSModulePath;<path-to-module-directory>"
+$env:PSModulePath = "$env:PSModulePath;<path-to-module-directory>"
 
 Import-Module -Name containers-toolkit -Force
 ```


### PR DESCRIPTION
`$env:PSModulePath += "$env:PSModulePath;<path-to-module-directory>"` duplicates the initial paths in PSModulePath before appending the `<path-to-module-directory>`

![image](https://github.com/microsoft/containers-toolkit/assets/28774968/59f7485a-4968-42ee-8144-c24f7e461f36)

![image](https://github.com/microsoft/containers-toolkit/assets/28774968/69183ee2-b0f6-4dee-abaf-f140b2cd0c03)


