### PR TITLE
[Bug] WaitForExit() hangs forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [ci-build-site]: https://github.com/microsoft/containers-toolkit/actions/workflows/ci-build.yaml
 [devskim-image]: https://github.com/microsoft/containers-toolkit/actions/workflows/sdl-compliance.yaml/badge.svg
 [devskim-site]: https://github.com/microsoft/containers-toolkit/actions/workflows/sdl-compliance.yaml
-[cf-image]: https://www.codefactor.io/repository/github/powershell/powershell/badge
-[cf-site]: https://www.codefactor.io/repository/github/powershell/powershell
+[cf-image]: https://www.codefactor.io/repository/github/microsoft/containers-toolkit/badge/main
+[cf-site]: https://www.codefactor.io/repository/github/microsoft/containers-toolkit/overview/main
 
 ## Table of contents
 

--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -230,7 +230,10 @@ function Register-BuildkitdService {
 
             # Check buildkitd service is already registered
             if (Test-ServiceRegistered -Service 'Buildkitd') {
-                Write-Warning "Buildkitd service already registered."
+                Write-Warning (-join @("buildkitd service already registered. To re-register the service, "
+                "stop the service by running 'Stop-Service buildkitd' or 'Stop-BuildkitdService', then "
+                "run 'buildkitd --unregister-service'. Wait for buildkitd service to be deregistered, "
+                "then re-reun this command."))
                 return
             }
 
@@ -404,14 +407,6 @@ function Uninstall-BuildkitHelper {
     Write-Output "Successfully uninstalled buildkit."
 }
 
-function Test-ConfFileEmpty($Path) {
-    if (!(Test-Path -LiteralPath $Path)) {
-        return $true
-    }
-
-    $isFileNotEmpty = (([System.IO.File]::ReadAllText($Path)) -match '\S')
-    return (-not $isFileNotEmpty )
-}
 
 function Get-ConsentToRegisterBuildkit ($path) {
     $retry = 2


### PR DESCRIPTION
Fix WaitForExit() in Invoke-ExecutableCommand() hangs forever even though the process has exited in some cases. This happens when the executable does not exit after completion. To mitigate this, we add a customisable timeout.