### PR TITLE
[Fix] Install when version is provided with leading 'v'

### DIFF
--- a/Tests/AllToolsUtilities.Tests.ps1
+++ b/Tests/AllToolsUtilities.Tests.ps1
@@ -213,12 +213,12 @@ Describe "AllToolsUtilities.psm1" {
 
         It "Should register services and initialize NAT network" {
             Install-ContainerTools `
-            -InstallPath 'TestDrive:\Install Directory' `
-            -Force -Confirm:$false `
-            -RegisterServices
+                -InstallPath 'TestDrive:\Install Directory' `
+                -Force -Confirm:$false `
+                -RegisterServices
 
             $RegisterContainerdParams = @{
-                ContainerdPath =  "$InstallPath\Containerd"
+                ContainerdPath = "$InstallPath\Containerd"
             }
             $RegisterBuildKitdParams = @{
                 BuildKitPath = "$InstallPath\Buildkit"
@@ -229,6 +229,13 @@ Describe "AllToolsUtilities.psm1" {
             Should -Invoke Register-BuildkitdService -ModuleName 'AllToolsUtilities' -Times 1 `
                 -ParameterFilter { $RegisterBuildKitdParams -and $Start -eq $true -and $Force -eq $true }
             Should -Invoke Initialize-NatNetwork -ModuleName 'AllToolsUtilities' -Times 1
+        }
+
+        It "Should not throw an error if initializing NAT network fails" {
+            Mock Initialize-NatNetwork -ModuleName 'AllToolsUtilities' -MockWith { throw 'Error message' }
+
+            { Install-ContainerTools -InstallPath 'TestDrive:\Install Directory' -Force -Confirm:$false -RegisterServices } | Should -Not -Throw
+            $Error[0].Exception.Message | Should -Be 'Failed to initialize NAT network. Error message'
         }
     }
 }

--- a/containers-toolkit/Private/CommonToolUtilities.psm1
+++ b/containers-toolkit/Private/CommonToolUtilities.psm1
@@ -64,7 +64,7 @@ function Get-InstallationFile {
     begin {
         $functions = {
             function Receive-File ($feature) {
-                Write-Information -InformationAction Continue -MessageData "Downloading $($feature.Feature) version $($feature.Version)"
+                Write-Information -InformationAction Continue -MessageData "Downloading $($feature.Feature) version v$($feature.Version)"
                 try {
                     Invoke-WebRequest -Uri $feature.Uri -OutFile $feature.DownloadPath -UseBasicParsing
                 }
@@ -107,7 +107,7 @@ function Get-InstallationFile {
     }
 
     end {
-        $jobs | Remove-Job -Force
+        $jobs | Remove-Job -Force -ErrorAction SilentlyContinue
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

1. Fix install when version is provided with leading 'v'. The Install command fails if a user passes the version with "v1.0.0".
    ```PowerShell
    Install-ContainerTools -NerdCTLVersion v1.7.2 -ContainerDVersion v1.6.4
    ```
2. Confirm option not passed to uninstall commands
3. Install-ContainerTools fails when Initialze-NatNetwork fails. Write-Error instead.