### PR TITLE
fix: minor fixes on the cni setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,20 @@ Containers-Toolkit is a Windows PowerShell module for downloading, installing, a
     git clone https://github.com/microsoft/containers-toolkit.git
     ```
 
-2. Add the directory to @indows PowerShell module path
+1. Add the directory to Windows PowerShell module path
 
     ```PowerShell
-    $env:PSModulePath = "$env:PSModulePath;<path-to-module-directory>"
+    $env:PSModulePath += ";<path-to-module-directory>"
     ```
 
-3. Import the module
+1. Install module dependencies
+
+    ```powershell
+    Install-Module -Name ThreadJob -Force
+    Install-Module -Name HNS -AllowClobber -Force
+    ```
+
+1. Import the module
 
     ```PowerShell
     Import-Module -Name containers-toolkit -Force

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -213,7 +213,7 @@ function Initialize-NatNetwork {
                     Subnet        = $subnet
                     CNIConfDir    = $cniConfDir
                 }
-                Set-DefaultCNICInfig @params
+                Set-DefaultCNIConfig @params
 
                 Write-Output "Successfully created new NAT network called '$($hnsNetwork.Name)' with Gateway $($hnsNetwork.Subnets.GatewayAddress), and Subnet Mask $($hnsNetwork.Subnets.AddressPrefix)"
             }
@@ -334,7 +334,7 @@ function Import-HNSModule {
             $DownloadParams = @(
                 @{
                     Feature      = "HNS.psm1"
-                    Uri          = 'https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1'
+                    Uri          = 'https://raw.githubusercontent.com/microsoft/SDN/dd4e8708ed184b49d3fddd611b6027f1755c6edb/Kubernetes/windows/hns.psm1'
                     DownloadPath = $WinCNIPath
                 }
             )
@@ -371,7 +371,7 @@ function Install-MissingPlugin {
 
 
 # FIXME: nerdctl- Warning when user tries to run container with this network config
-function Set-DefaultCNICInfig {
+function Set-DefaultCNIConfig {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = 'Low'


### PR DESCRIPTION
- use permalink for `hns.psm1` module to protect against script change (content or location). BTW, there is also a v2[1] of the same script, I don't know if we should consider it?
- small typo fix for `Set-DefaultCNICInfig` -> `Set-DefaultCNIConfig`

[1] https://github.com/microsoft/SDN/blob/master/Kubernetes/windows/hns.v2.psm1

Plus small fix in the installation steps on the README.md