### PR TITLE
Reuse install commands in 'install-containertools

### DIFF
--- a/containers-toolkit/en-US/containers-toolkit-help.xml
+++ b/containers-toolkit/en-US/containers-toolkit-help.xml
@@ -1045,17 +1045,6 @@
           <dev:defaultValue>$HOME\Downloads</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>CleanUp</maml:name>
-          <maml:description>
-            <maml:para>Cleanup after installation is done</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Confirm</maml:name>
           <maml:description>
             <maml:para>Prompts for confirmation before running the cmdlet. For more information, see the following articles:</maml:para>
@@ -1088,7 +1077,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>RegisterServices</maml:name>
           <maml:description>
-            <maml:para>Register and Start Conatinerd and Buildkitd services and set up NAT network.</maml:para>
+            <maml:para>Register and Start Containerd and Buildkitd services and set up NAT network.</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1121,18 +1110,6 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>Latest version</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>CleanUp</maml:name>
-        <maml:description>
-          <maml:para>Cleanup after installation is done</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>Confirm</maml:name>
@@ -1193,7 +1170,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>RegisterServices</maml:name>
         <maml:description>
-          <maml:para>Register and Start Conatinerd and Buildkitd services and set up NAT network.</maml:para>
+          <maml:para>Register and Start Containerd and Buildkitd services and set up NAT network.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/docs/About/Install-ContainerTools.md
+++ b/docs/About/Install-ContainerTools.md
@@ -15,7 +15,7 @@ Downloads and installs container tool (Containerd, BuildKit, and nerdctl).
 
 ```
 Install-ContainerTools [[-ContainerDVersion] <String>] [[-BuildKitVersion] <String>]
- [[-NerdCTLVersion] <String>] [[-InstallPath] <String>] [[-DownloadPath] <String>] [-CleanUp] [-Force] [-RegisterServices]
+ [[-NerdCTLVersion] <String>] [[-InstallPath] <String>] [[-DownloadPath] <String>] [-Force] [-RegisterServices]
  [-Confirm] [-WhatIf] [<CommonParameters>]
 ```
 
@@ -41,17 +41,9 @@ Download Containerd version 1.6.8 and default nerdctl and BuildKit versions
 PS C:\> Install-ContainerTools -ContainerDVersion 1.6.8
 ```
 
-### Example 3: Cleanup after installation is complete
+### Example 3: Register and Start Containerd and Buildkitd services and set up NAT network
 
-Deletes downloaded files after installation is complete to save on disk space.
-
-```powershell
-PS C:\> Install-ContainerTools -Cleanup
-```
-
-### Example 4: Register and Start Conatinerd and Buildkitd services and set up NAT network
-
-Register and Start Conatinerd and Buildkitd services and set up NAT network
+Register and Start Containerd and Buildkitd services and set up NAT network
 
 ```powershell
 PS C:\> Install-ContainerTools -RegisterServices
@@ -71,22 +63,6 @@ Aliases:
 Required: False
 Position: 1
 Default value: Latest version
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CleanUp
-
-Cleanup after installation is done
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -160,7 +136,7 @@ Accept wildcard characters: False
 
 ### -RegisterServices
 
-Register and Start Conatinerd and Buildkitd services and set up NAT network.
+Register and Start Containerd and Buildkitd services and set up NAT network.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -60,7 +60,6 @@ Downloads container tool (Containerd, BuildKit, nerdctl) asynchronously and inst
 | nerdctlVersion | String | nerdctl version to install | Latest version |
 | InstallPath | String | Path to install container tools | `$Env:ProgramFiles` |
 | DownloadPath | String | Path to download container tools  | `$HOME\Downloads` |
-| Cleanup | Switch | Specifies whether to cleanup after installation is done  |  |
 | Force | Switch | Force install the tools even if they already exists at the specified path |  |
 | RegisterServices | Switch | Register and Start Containerd and Buildkitd services and set up NAT network |  |
 | Confirm | Switch | Prompts for confirmation before running the cmdlet. For more information, see the following articles: [about_Preference_Variables](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.4#confirmpreference) and [about_Functions_CmdletBindingAttribute](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-7.4#confirmimpact) |  |


### PR DESCRIPTION
# PR Description

Reuse install commands for each tool (e.g. Install-Containerd, etc) in the `Install-ContainerTools` command. This makes it easier to maintain the  `Install-ContainerTools` command.