### PR TITLE
[Bug] Backward compatibility: Test-JSONChecksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can find documentation for these functions here: [Containers-Toolkit Documen
 
 ## Prerequisites
 
-This module requires `ThreadJob` and `HNS` modules.
+1. PowerShell: Minimum Version 7
 
 1. `ThreadJob` module
 

--- a/Tests/CommonToolUtilities.Tests.ps1
+++ b/Tests/CommonToolUtilities.Tests.ps1
@@ -423,18 +423,10 @@ Describe "CommonToolUtilities.psm1" {
             }
 
             # Validate Checksum file content
-            Should -Invoke Get-Content -ModuleName "CommonToolUtilities" -ParameterFilter {
-                $Path -eq $Script:ChecksumFile
-            }
+            Should -Invoke Get-Content -ModuleName "CommonToolUtilities" -ParameterFilter { $Path -eq $Script:ChecksumFile }
 
             # Validate JSON file
-            # Should -Invoke Get-Content -ModuleName "CommonToolUtilities" -ParameterFilter {
-            #     $Path -eq "$Script:SchemaFile"
-            # } # FIXME: This test is failing
-            Should -Invoke Test-Json -Times 1 -Scope It -ModuleName "CommonToolUtilities" -ParameterFilter {
-                $Path -eq $Script:ChecksumFile -and
-                $SchemaFile -eq $Script:SchemaFile
-            }
+            Should -Invoke Test-Json -Times 1 -Scope It -ModuleName "CommonToolUtilities"
 
             # Assert success
             Should -Invoke Get-FileHash -Times 1 -Scope It -ModuleName "CommonToolUtilities" -ParameterFilter {
@@ -467,12 +459,12 @@ Describe "CommonToolUtilities.psm1" {
 
             # Validate JSON file
             Should -Invoke Get-Content -Times 1 -Scope It -ModuleName "CommonToolUtilities" -ParameterFilter {
+                $Path -eq $Script:ChecksumFile
+            }
+            Should -Invoke Get-Content -Times 1 -Scope It -ModuleName "CommonToolUtilities" -ParameterFilter {
                 $Path -eq $Script:SchemaFile
             }
-            Should -Invoke Test-Json -Times 1 -Scope It -ModuleName "CommonToolUtilities" -ParameterFilter {
-                $Path -eq $Script:ChecksumFile -and
-                $SchemaFile -eq $Script:SchemaFile
-            }
+            Should -Invoke Test-Json -Times 1 -Scope It -ModuleName "CommonToolUtilities"
 
             # Assert success
             Should -Invoke Get-FileHash -Times 1 -Scope It -ModuleName "CommonToolUtilities" -ParameterFilter {

--- a/containers-toolkit/Private/CommonToolUtilities.psm1
+++ b/containers-toolkit/Private/CommonToolUtilities.psm1
@@ -1,4 +1,4 @@
-﻿###########################################################################
+###########################################################################
 #                                                                         #
 #   Copyright (c) Microsoft Corporation. All rights reserved.             #
 #                                                                         #
@@ -339,6 +339,7 @@ function DownloadCheckSumFile {
         Throw "Checksum file download failed: $checksumUri.`n$($_.Exception.Message)"
     }
 
+    Write-Debug "Checksum file downloaded to `"$OutFile`""
     return $OutFile
 }
 
@@ -349,6 +350,8 @@ function ValidateJSONChecksumFile {
         [parameter(Mandatory = $true, HelpMessage = "JSON schema file path")]
         [String]$SchemaFile
     )
+
+    Write-Debug "Validating JSON checksum file...`n`tChecksum file path:$ChecksumFilePath`n`tSchema file: $SchemaFile"
 
     # Check if the schema file exists
     if (-not (Test-Path -Path $SchemaFile)) {
@@ -362,8 +365,8 @@ function ValidateJSONChecksumFile {
 
     # Test JSON checksum file is valid
     try {
-        Write-Debug "Validating checksum JSON file $checksumFilePath"
-        return (Test-Json -Path "$checksumFilePath" -SchemaFile $SchemaFile)
+        $isValidJSON = Test-Json -Json (Get-Content -Path $checksumFilePath -Raw) -Schema (Get-Content -Path $schemafile -Raw)
+	return $isValidJSON
     }
     catch {
         Throw "Invalid JSON format in checksum file. $_"


### PR DESCRIPTION
## PR description

The command syntax for Test-JSON differs between PowerShell versions 7.2 (used in #35) and 7.4 (used to develop this module). For backward compatibility, we use the syntax common to both versions: Test-Json -Json <json-string> -Schema <json-string> instead of Test-Json -Path <path> -SchemaFile <path>.

### Github issue/ discussion

Issue #35 

### Relevant links

- [Test-Json PowerShell 7.2](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/test-json?view=powershell-7.2)
- [Test-Json PowerShell 7.4](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/test-json?view=powershell-7.4)

## Checklist

As part of our commitment to engineering excellence, **before** submitting this PR, please make sure:

- [x] You've tested this code in both Desktop & Server environments and AMD & ARM64 enviroments (**functional testing**).
- [x] You've added **unit tests** for new code.
- [x] You've added/updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md)  and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [x] You've reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please agree to:

- [ ] If changes have been made to your PR in the process of addressing comments, please make sure to test again the _final_ version in both AMD and ARM64 environments.
- [ ] Validate your changes have not introduced any regressions.
