### PR TITLE
Remove ThreadJob Module dependency

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -100,7 +100,7 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          $requiredModules = @('Pester', 'ThreadJob')
+          $requiredModules = @('Pester')
           $missingModules = $requiredModules | Where-Object { -not (Get-Module -ListAvailable -Name $_) }
 
           if ($missingModules) {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,19 +42,6 @@ jobs:
           path: "C:\\program files\\powershell\\7\\Modules"
           key: ${{ runner.os }}-CTK
 
-      - name: Install required PowerShell modules
-        if: steps.cacher.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          $requiredModules = @('ThreadJob')
-          $missingModules = $requiredModules | Where-Object { -not (Get-Module -ListAvailable -Name $_) }
-
-          if ($missingModules) {
-            Write-Output "Modules to install: $($missingModules -join ', ')"
-            Install-Module $missingModules -ErrorAction Stop -AllowClobber -SkipPublisherCheck -Force
-          }
-
       - name: Update module version
         id: update-version
         shell: pwsh

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -36,7 +36,6 @@
         "PowerShell",
         "/PSCustomObject/gi",
         "subnet",
-        "ThreadJob",
         "/unregisters/gi",
         "WinCNIPlugin",
         // Parameter names

--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ You can find documentation for these functions here: [Containers-Toolkit Documen
 
 1. PowerShell: Minimum Version 7
 
-1. `ThreadJob` module
-
-    ```powershell
-    Install-Module -Name ThreadJob -Force
-    ```
-
 1. `HNS` module
 
     To install the HNS module, follow the [instructions here](./docs/FAQs.md#2-new-hnsnetwork-command-does-not-exist)
@@ -123,7 +117,7 @@ Get-Command -Module containers-toolkit
     Enable-WindowsOptionalFeature -Online -FeatureName '<Feature-Name-Here>' -All -NoRestart
     ```
 
-1. Requires PowerShell modules [HNS](https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.v2.psm1) and [ThreadJob](https://www.powershellgallery.com/packages/ThreadJob)
+1. Requires PowerShell modules [HNS](https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.v2.psm1)
 
 ## FAQs
 

--- a/Tests/CommonToolUtilities.Tests.ps1
+++ b/Tests/CommonToolUtilities.Tests.ps1
@@ -144,19 +144,10 @@ Describe "CommonToolUtilities.psm1" {
 
     Context "Get-InstallationFile" -Tag "Get-InstallationFile" {
         BeforeEach {
-            Mock Get-Module -ParameterFilter { $Name -eq 'ThreadJob' } { }
-            Mock Import-Module -ParameterFilter { $Name -eq 'ThreadJob' } { }
             Mock Invoke-WebRequest -ModuleName "CommonToolUtilities" { }
             Mock Invoke-RestMethod -ModuleName "CommonToolUtilities" {
                 return (Get-Content -Path "$PSScriptRoot\TestData\release-assets.json" -Raw | ConvertFrom-Json -Depth 3 )
             }
-            # -ParameterFilter { $Uri -match "https://api.github.com/repos/containerd/nerdctl/releases" }
-
-            $sampleJob = New-MockObject -Type 'ThreadJob.ThreadJob' -Properties @{ JobStateInfo = 'Completed' }
-            Mock Start-ThreadJob -ModuleName "CommonToolUtilities" -MockWith { return $sampleJob }
-            Mock Wait-Job -ModuleName "CommonToolUtilities"
-            Mock Receive-Job -ModuleName "CommonToolUtilities"
-            Mock Remove-Job -ModuleName "CommonToolUtilities"
             Mock Test-Checksum -ModuleName "CommonToolUtilities" -MockWith { return $true }
 
             $Script:TestFileName = "nerdctl-2.0.0-rc.1-windows-amd64.tar.gz"

--- a/build/scripts/run-tests.ps1
+++ b/build/scripts/run-tests.ps1
@@ -94,11 +94,6 @@ Write-Output "Importing modules"
 Import-Module PowerShellGet # Needed to avoid error: "CommandNotFoundException: Could not find Command Install-Module"
 Import-Module Pester -Force
 
-if (!(Get-Module -ListAvailable -Name ThreadJob)) {
-    Install-Module -Name ThreadJob -Force
-}
-Import-Module -Name ThreadJob -Force
-
 #######################################################
 ################### DISCONVER TESTS ###################
 #######################################################

--- a/containers-toolkit/containers-toolkit.psd1
+++ b/containers-toolkit/containers-toolkit.psd1
@@ -27,7 +27,7 @@ The Containers-Toolkit module contains PowerShell functions for downloading, ins
 Configurations done with these functions are default configurations that allow you to get started with interacting with the tools. Further configurations may be necessary.
 You can find documentation for these functions here: [Containers-Toolkit Documentation](https://github.com/microsoft/containers-toolkit/tree/main/docs/command-reference.md)
 
-This module requires the ThreadJob module. Additionally, it requires the HNS module to execute the "Initialize-NatNetwork" command. The Host Networking Service (HNS) and the Host Compute Service (HCS) work together to create containers and attach endpoints to a network. The HNS module is necessary because the HostNetworkingService module does not include the "New-HNSNetwork" cmdlet.
+This module requires the HNS module to execute the "Initialize-NatNetwork" command. The Host Networking Service (HNS) and the Host Compute Service (HCS) work together to create containers and attach endpoints to a network. The HNS module is necessary because the HostNetworkingService module does not include the "New-HNSNetwork" cmdlet.
 
 Note that the HostNetworkingService module is available only when the Hyper-V Windows feature is enabled.
 "@
@@ -51,7 +51,7 @@ Note that the HostNetworkingService module is available only when the Hyper-V Wi
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules   = @( 'ThreadJob' )
+    # RequiredModules   = @()
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()
@@ -157,7 +157,7 @@ Note that the HostNetworkingService module is available only when the Hyper-V Wi
             RequireLicenseAcceptance   = $true
 
             # External dependent modules of this module
-            ExternalModuleDependencies = @('ThreadJob')
+            # ExternalModuleDependencies = @()
 
         } # End of PSData hashtable
 

--- a/containers-toolkit/en-US/about_containers-toolkit.help.txt
+++ b/containers-toolkit/en-US/about_containers-toolkit.help.txt
@@ -20,7 +20,7 @@ LONG DESCRIPTION
     configurations may be necessary.
     You can find documentation for these functions here:
         https://github.com/microsoft/containers-toolkit/tree/main/docs/command-reference.md
-    This module requires the ThreadJob and HNS modules. To install these modules, refer to
+    This module requires the HNS module. To install these modules, refer to
         https://github.com/microsoft/containers-toolkit/tree/main/docs/README.md#prerequisites
 
 


### PR DESCRIPTION
## PR description

### Github issue/ discussion ()

_related Isuue/discussion(s)_

### Background information

ThreadJob is not used in the Containers.Toolkit module. Removing this dependency.

As part of our commitment to engineering excellence, **before** submitting this PR, please make sure:

- [x] You've tested this code in both Desktop & Server environments and AMD & ARM64 enviroments (**functional testing**).
- [ ] You've added **unit tests** for new code.
- [ ] You've added/updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md)  and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [ ] You've reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please agree to:

- [x] If changes have been made to your PR in the process of addressing comments, please make sure to test again the _final_ version in both AMD and ARM64 environments.
- [x] Validate your changes have not introduced any regressions.
