### PR TITLE
Refactor uninstall commands

### DIFF
--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -289,7 +289,7 @@ function Uninstall-WinCNIPlugin {
     )]
     param(
         [parameter(HelpMessage = "Windows CNI plugin path")]
-        [String]$Path,
+        [String]$Path="$ENV:ProgramFiles\Containerd\cni",
 
         [parameter(HelpMessage = "Bypass confirmation to uninstall Windows CNI plugins")]
         [Switch] $Force
@@ -327,7 +327,7 @@ function Uninstall-WinCNIPlugin {
 
             Write-Warning "Uninstalling preinstalled Windows CNI plugin at the path $path"
             try {
-                Uninstall-WinCNIPluginHelper -Path $path
+                Uninstall-WinCNIPluginHelper -Path $path | Out-Null
             }
             catch {
                 Throw "Could not uninstall $tool. $_"
@@ -345,7 +345,7 @@ function Uninstall-WinCNIPluginHelper {
     param(
         [ValidateNotNullOrEmpty()]
         [parameter(HelpMessage = "Windows CNI plugin path")]
-        [String]$Path
+        [String]$Path="$ENV:ProgramFiles\Containerd\cni"
     )
 
     Write-Output "Uninstalling Windows CNI plugin"


### PR DESCRIPTION
## PR description

Refactor the uninstall commands to only remove program data (program data folder, config files, env variable, and RegKeys) when the `-purge` flag is passed.

### Github issue

[Uninstall-Containerd too destructive #40](https://github.com/microsoft/containers-toolkit/issues/40)


### Background information

Running the uninstall command currently deletes the program data as well. This is too destructive as the user would like to retain these folders/files (e.g. Containerd snapshot folder) even after installing another version (either an upgrade or an upgrade).

To resolve this, we add a `-purge` flag that when passed in the uninstall command, the program data will be removed, otherwise, it will be retained.

### Testing information

Examples: To uninstall containerd

1. _WhatIf_
    ```PowerShell
    > Uninstall-Containerd -WhatIf
    
    What if: Performing the operation "Containerd will be uninstalled from 'C:\Program Files\Containerd'' and containerd service     will be stopped and unregistered" on target "COMPUTERNAME".
    ```

1. Retain the program data
    ```powershell
    Uninstall-Containerd
    ```
1. Purge program data
    ```powershell
    Uninstall-Containerd -Purge
    ```
## Checklist

As part of our commitment to engineering excellence, **before** submitting this PR, please make sure:

- [ ] You've tested this code in both Desktop & Server environments and AMD & ARM64 enviroments (**functional testing**).
- [ ] You've added **unit tests** for new code.
- [ ] You've added/updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md)  and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [ ] You've reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please agree to:

- [ ] If changes have been made to your PR in the process of addressing comments, please make sure to test again the _final_ version in both AMD and ARM64 environments.
- [ ] Validate your changes have not introduced any regressions.
