### PR TITLE
Refactor uninstall to add -purge flag

### DIFF
--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -59,13 +59,13 @@ function Install-Buildkit {
         # Check if Buildkit is alread installed
         $isInstalled = -not (Test-EmptyDirectory -Path $InstallPath)
 
-        $WhatIfMessage = "Buildkit will be installed at $InstallPath"
+        $WhatIfMessage = "Buildkit will be installed at '$InstallPath'"
         if ($isInstalled) {
-            $WhatIfMessage = "Buildkit will be uninstalled from and reinstalled at $InstallPath"
+            $WhatIfMessage = "Buildkit will be uninstalled from and reinstalled at '$InstallPath'"
         }
         if ($Setup) {
             <# Action when this condition is true #>
-            $WhatIfMessage = "Buildkit will be installed at $InstallPath and buildkitd service will be registered and started"
+            $WhatIfMessage = "Buildkit will be installed at '$InstallPath' and buildkitd service will be registered and started"
         }
     }
 
@@ -73,7 +73,7 @@ function Install-Buildkit {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "Buildkit already exists at $InstallPath or the directory is not empty" + `
+                $errMsg = "Buildkit already exists at '$InstallPath' or the directory is not empty" + `
                 "`nProgram data won't be removed. To remove program data, run 'Uninstall-Buildkit' command with -Purge flag."
                 Write-Warning $errMsg
 
@@ -355,7 +355,7 @@ function Uninstall-Buildkit {
             $Path = Get-DefaultInstallPath -Tool $tool
         }
 
-        $WhatIfMessage = "Buildkit will be uninstalled from $path and buildkitd service will be stopped and unregistered."
+        $WhatIfMessage = "Buildkit will be uninstalled from '$path' and buildkitd service will be stopped and unregistered."
         if ($Purge) {
             $WhatIfMessage += " Buildkit program data will also be removed."
         }
@@ -366,23 +366,23 @@ function Uninstall-Buildkit {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-            if (Test-EmptyDirectory -Path $path) {
-                Write-Output "$tool does not exist at $Path or the directory is empty"
+            if (Test-EmptyDirectory -Path "$path") {
+                Write-Output "$tool does not exist at '$Path' or the directory is empty"
                 return
             }
 
             $consent = $force
             if (!$ENV:PESTER) {
-                $consent = $force -or $PSCmdlet.ShouldContinue($env:COMPUTERNAME, "Are you sure you want to uninstall Buildkit from $path?")
+                $consent = $force -or $PSCmdlet.ShouldContinue($env:COMPUTERNAME, "Are you sure you want to uninstall Buildkit from '$path'?")
             }
 
             if (!$consent) {
                 Throw "$tool uninstallation cancelled."
             }
 
-            Write-Warning "Uninstalling preinstalled $tool at the path $path"
+            Write-Warning "Uninstalling preinstalled $tool at the path '$path'"
             try {
-                Uninstall-BuildkitHelper -Path $path -Purge:$Purge | Out-Null
+                Uninstall-BuildkitHelper -Path "$path" -Purge:$Purge
             }
             catch {
                 Throw "Could not uninstall $tool. $_"
@@ -405,15 +405,15 @@ function Uninstall-BuildkitHelper {
         [Switch] $Purge
     )
 
-    if (Test-EmptyDirectory -Path $Path) {
-        Write-Error "Buildkit does not exist at $Path or the directory is empty."
+    if (Test-EmptyDirectory -Path "$Path") {
+        Write-Error "Buildkit does not exist at '$Path' or the directory is empty."
         return
     }
 
     try {
         if (Test-ServiceRegistered -Service 'Buildkitd') {
             Stop-BuildkitdService
-            Unregister-Buildkitd -BuildkitPath $Path
+            Unregister-Buildkitd -BuildkitPath "$Path"
         }
     }
     catch {
@@ -421,7 +421,7 @@ function Uninstall-BuildkitHelper {
     }
 
     # Remove the folder where buildkit is installed and related folders
-    Remove-Item -Path $Path -Recurse -Force
+    Remove-Item -Path "$Path" -Recurse -Force
 
     if ($Purge) {
         Write-Output "Purging Buildkit program data"

--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -73,8 +73,7 @@ function Install-Buildkit {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "Buildkit already exists at '$InstallPath' or the directory is not empty" + `
-                "`nProgram data won't be removed. To remove program data, run 'Uninstall-Buildkit' command with -Purge flag."
+                $errMsg = "Buildkit already exists at '$InstallPath' or the directory is not empty."
                 Write-Warning $errMsg
 
                 # Uninstall if tool exists at specified location. Requires user consent
@@ -380,7 +379,7 @@ function Uninstall-Buildkit {
                 Throw "$tool uninstallation cancelled."
             }
 
-            Write-Warning "Uninstalling preinstalled $tool at the path '$path'"
+            Write-Warning "Uninstalling preinstalled $tool at the path '$path'.`n$WhatIfMessage"
             try {
                 Uninstall-BuildkitHelper -Path "$path" -Purge:$Purge
             }

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -64,7 +64,7 @@ function Install-WinCNIPlugin {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "Windows CNI plugins already exists at '$WinCNIPath' or the directory is not empty"
+                $errMsg = "Windows CNI plugins already exists at '$WinCNIPath' or the directory is not empty."
                 Write-Warning $errMsg
 
                 # Uninstall if tool exists at specified location. Requires user consent

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -47,16 +47,16 @@ function Install-WinCNIPlugin {
             $containerdPath = Get-DefaultInstallPath -Tool "containerd"
             $WinCNIPath = "$containerdPath\cni"
         }
-        $WinCNIPath = $WinCNIPath -replace '(\\bin)$', ''
+        $WinCNIPath = "$WinCNIPath" -replace '(\\bin)$', ''
 
         # Check if Containerd is alread installed
-        $isInstalled = -not (Test-EmptyDirectory -Path $WinCNIPath)
+        $isInstalled = -not (Test-EmptyDirectory -Path "$WinCNIPath")
 
         $plugin = "Windows CNI plugins"
 
-        $WhatIfMessage = "$plugin will be installed at $WINCNIPath"
+        $WhatIfMessage = "$plugin will be installed at '$WINCNIPath'"
         if ($isInstalled) {
-            $WhatIfMessage = "$plugin will be uninstalled from and reinstalled at $WINCNIPath"
+            $WhatIfMessage = "$plugin will be uninstalled from and reinstalled at '$WINCNIPath'"
         }
     }
 
@@ -64,7 +64,7 @@ function Install-WinCNIPlugin {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "Windows CNI plugins already exists at $WinCNIPath or the directory is not empty"
+                $errMsg = "Windows CNI plugins already exists at '$WinCNIPath' or the directory is not empty"
                 Write-Warning $errMsg
 
                 # Uninstall if tool exists at specified location. Requires user consent
@@ -327,7 +327,7 @@ function Uninstall-WinCNIPlugin {
 
             Write-Warning "Uninstalling preinstalled Windows CNI plugin at the path $path"
             try {
-                Uninstall-WinCNIPluginHelper -Path $path | Out-Null
+                Uninstall-WinCNIPluginHelper -Path $path
             }
             catch {
                 Throw "Could not uninstall $tool. $_"

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -289,7 +289,7 @@ function Uninstall-WinCNIPlugin {
     )]
     param(
         [parameter(HelpMessage = "Windows CNI plugin path")]
-        [String]$Path,
+        [String]$Path="$ENV:ProgramFiles\Containerd\cni",
 
         [parameter(HelpMessage = "Bypass confirmation to uninstall Windows CNI plugins")]
         [Switch] $Force
@@ -327,7 +327,7 @@ function Uninstall-WinCNIPlugin {
 
             Write-Warning "Uninstalling preinstalled Windows CNI plugin at the path $path"
             try {
-                Uninstall-WinCNIPluginHelper -Path $path
+                Uninstall-WinCNIPluginHelper -Path $path | Out-Null
             }
             catch {
                 Throw "Could not uninstall $tool. $_"
@@ -345,7 +345,7 @@ function Uninstall-WinCNIPluginHelper {
     param(
         [ValidateNotNullOrEmpty()]
         [parameter(HelpMessage = "Windows CNI plugin path")]
-        [String]$Path
+        [String]$Path="$ENV:ProgramFiles\Containerd\cni"
     )
 
     Write-Output "Uninstalling Windows CNI plugin"

--- a/containers-toolkit/Public/ContainerdTools.psm1
+++ b/containers-toolkit/Public/ContainerdTools.psm1
@@ -62,8 +62,7 @@ function Install-Containerd {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "Containerd already exists at '$InstallPath' or the directory is not empty. " + `
-                    "`nProgram data won't be removed. To remove program data, run 'Uninstall-Containerd' command with -Purge flag."
+                $errMsg = "Containerd already exists at '$InstallPath' or the directory is not empty."
                 Write-Warning $errMsg
 
                 # Uninstall if tool exists at specified location. Requires user consent
@@ -344,7 +343,7 @@ function Uninstall-Containerd {
                 Throw "$tool uninstallation cancelled."
             }
 
-            Write-Warning "Uninstalling preinstalled $tool at the path '$path'"
+            Write-Warning "Uninstalling preinstalled $tool at the path '$path'.`n$WhatIfMessage"
             try {
                 Uninstall-ContainerdHelper -Path "$path" -Purge:$Purge
             }

--- a/containers-toolkit/Public/ContainerdTools.psm1
+++ b/containers-toolkit/Public/ContainerdTools.psm1
@@ -48,13 +48,13 @@ function Install-Containerd {
         # Check if Containerd is alread installed
         $isInstalled = -not (Test-EmptyDirectory -Path "$InstallPath\bin")
 
-        $WhatIfMessage = "Containerd will be installed at $InstallPath"
+        $WhatIfMessage = "Containerd will be installed at '$InstallPath'"
         if ($isInstalled) {
-            $WhatIfMessage = "Containerd will be uninstalled from and reinstalled at $InstallPath"
+            $WhatIfMessage = "Containerd will be uninstalled from and reinstalled at '$InstallPath'"
         }
         if ($Setup) {
             <# Action when this condition is true #>
-            $WhatIfMessage = "Containerd will be installed at $InstallPath and containerd service will be registered and started"
+            $WhatIfMessage = "Containerd will be installed at '$InstallPath' and containerd service will be registered and started"
         }
     }
 
@@ -62,7 +62,7 @@ function Install-Containerd {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "Containerd already exists at $InstallPath or the directory is not empty. " + `
+                $errMsg = "Containerd already exists at '$InstallPath' or the directory is not empty. " + `
                     "`nProgram data won't be removed. To remove program data, run 'Uninstall-Containerd' command with -Purge flag."
                 Write-Warning $errMsg
 
@@ -319,7 +319,7 @@ function Uninstall-Containerd {
             $path = $path.TrimEnd("\").Trim() + "\bin"
         }
 
-        $WhatIfMessage = "Containerd will be uninstalled from $path and containerd service will be stopped and unregistered."
+        $WhatIfMessage = "Containerd will be uninstalled from '$path' and containerd service will be stopped and unregistered."
         if ($Purge) {
             $WhatIfMessage += " Containerd program data will also be removed."
         }
@@ -344,9 +344,9 @@ function Uninstall-Containerd {
                 Throw "$tool uninstallation cancelled."
             }
 
-            Write-Warning "Uninstalling preinstalled $tool at the path $path"
+            Write-Warning "Uninstalling preinstalled $tool at the path '$path'"
             try {
-                Uninstall-ContainerdHelper -Path $path -Purge:$Purge | Out-Null
+                Uninstall-ContainerdHelper -Path "$path" -Purge:$Purge
             }
             catch {
                 Throw "Could not uninstall $tool. $_"
@@ -370,7 +370,7 @@ function Uninstall-ContainerdHelper {
         [Switch] $Purge
     )
 
-    if (Test-EmptyDirectory -Path $Path) {
+    if (Test-EmptyDirectory -Path "$Path") {
         Write-Error "Containerd does not exist at $Path or the directory is empty."
         return
     }
@@ -378,7 +378,7 @@ function Uninstall-ContainerdHelper {
     try {
         if (Test-ServiceRegistered -Service 'containerd') {
             Stop-ContainerdService
-            Unregister-Containerd -ContainerdPath $Path
+            Unregister-Containerd -ContainerdPath "$Path"
         }
     }
     catch {
@@ -386,7 +386,7 @@ function Uninstall-ContainerdHelper {
     }
 
     # Remove the folder where containerd is installed and related folders
-    Remove-Item -Path $Path -Recurse -Force
+    Remove-Item -Path "$Path" -Recurse -Force
 
     if ($Purge) {
         Write-Output "Purging Containerd program data"
@@ -414,7 +414,7 @@ function Unregister-Containerd ($containerdPath) {
     }
 
     # Unregister containerd service
-    $containerdExecutable = "$ContainerdPath\bin\containerd.exe"
+    $containerdExecutable = (Get-ChildItem -Path "$ContainerdPath" -Recurse -Filter "containerd.exe").FullName | Select-Object -First 1
     $output = Invoke-ExecutableCommand -Executable $containerdExecutable -Arguments "--unregister-service"
     if ($output.ExitCode -ne 0) {
         Throw "Could not unregister containerd service. $($output.StandardError.ReadToEnd())"

--- a/containers-toolkit/Public/NerdctlTools.psm1
+++ b/containers-toolkit/Public/NerdctlTools.psm1
@@ -110,8 +110,7 @@ function Install-Nerdctl {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "nerdctl already exists at '$InstallPath' or the directory is not empty" + `
-                    "`nProgram data won't be removed. To remove program data, run 'Uninstall-Nerdctl' command with -Purge flag."
+                $errMsg = "nerdctl already exists at '$InstallPath' or the directory is not empty."
                 Write-Warning $errMsg
 
                 # Uninstall if tool exists at specified location. Requires user consent
@@ -240,7 +239,7 @@ function Uninstall-Nerdctl {
                 Throw "$tool uninstallation cancelled."
             }
 
-            Write-Warning "Uninstalling preinstalled $tool at the path '$path'"
+            Write-Warning "Uninstalling preinstalled $tool at the path '$path'.`n$WhatIfMessage"
             try {
                 Uninstall-NerdctlHelper -Path "$path" -Purge:$Purge
             }

--- a/containers-toolkit/Public/NerdctlTools.psm1
+++ b/containers-toolkit/Public/NerdctlTools.psm1
@@ -87,7 +87,7 @@ function Install-Nerdctl {
 
     begin {
         # Check if Containerd is alread installed
-        $isInstalled = -not (Test-EmptyDirectory -Path $InstallPath)
+        $isInstalled = -not (Test-EmptyDirectory -Path "$InstallPath")
 
         $toInstall = @("nerdctl")
 
@@ -96,9 +96,9 @@ function Install-Nerdctl {
             $toInstall += $dependencies
         }
 
-        $WhatIfMessage = "nerdctl will be installed at $installPath"
+        $WhatIfMessage = "nerdctl will be installed at '$installPath'"
         if ($isInstalled) {
-            $WhatIfMessage = "nerdctl will be uninstalled from and reinstalled at $installPath"
+            $WhatIfMessage = "nerdctl will be uninstalled from and reinstalled at '$installPath'"
         }
         if ($dependencies) {
             <# Action when this condition is true #>
@@ -110,7 +110,7 @@ function Install-Nerdctl {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
             # Check if tool already exists at specified location
             if ($isInstalled) {
-                $errMsg = "nerdctl already exists at $InstallPath or the directory is not empty" + `
+                $errMsg = "nerdctl already exists at '$InstallPath' or the directory is not empty" + `
                     "`nProgram data won't be removed. To remove program data, run 'Uninstall-Nerdctl' command with -Purge flag."
                 Write-Warning $errMsg
 
@@ -215,7 +215,7 @@ function Uninstall-Nerdctl {
             $Path = Get-DefaultInstallPath -Tool "nerdctl"
         }
 
-        $WhatIfMessage = "nerdctl will be uninstalled from $Path."
+        $WhatIfMessage = "nerdctl will be uninstalled from '$Path'."
         if ($Purge) {
             $WhatIfMessage += " nerdctl program data will also be removed."
         }
@@ -226,8 +226,8 @@ function Uninstall-Nerdctl {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-            if (Test-EmptyDirectory -Path $path) {
-                Write-Output "$tool does not exist at $Path or the directory is empty"
+            if (Test-EmptyDirectory -Path "$path") {
+                Write-Output "$tool does not exist at '$Path' or the directory is empty"
                 return
             }
 
@@ -240,9 +240,9 @@ function Uninstall-Nerdctl {
                 Throw "$tool uninstallation cancelled."
             }
 
-            Write-Warning "Uninstalling preinstalled $tool at the path $path"
+            Write-Warning "Uninstalling preinstalled $tool at the path '$path'"
             try {
-                Uninstall-NerdctlHelper -Path $path -Purge:$Purge | Out-Null
+                Uninstall-NerdctlHelper -Path "$path" -Purge:$Purge
             }
             catch {
                 Throw "Could not uninstall $tool. $_"
@@ -266,13 +266,13 @@ function Uninstall-NerdctlHelper {
         [Switch] $Purge
     )
 
-    if (Test-EmptyDirectory -Path $Path) {
-        Write-Error "nerdctl does not exist at $Path or the directory is empty."
+    if (Test-EmptyDirectory -Path "$Path") {
+        Write-Error "nerdctl does not exist at '$Path' or the directory is empty."
         return
     }
 
     # Remove the folder where nerdctl is installed and related folders
-    Remove-Item -Path $Path -Recurse -Force
+    Remove-Item -Path "$Path" -Recurse -Force
 
     if ($Purge) {
         Write-Output "Purging nerdctl program data"


### PR DESCRIPTION
## PR description

Refactor the uninstall commands to only remove program data (program data folder, config files, env variable, and RegKeys) when the `-purge` flag is passed.

### Github issue

[Uninstall-Containerd too destructive #40](https://github.com/microsoft/containers-toolkit/issues/40)


### Background information

Running the uninstall command currently deletes the program data as well. This is too destructive as the user would like to retain these folders/files (e.g. Containerd snapshot folder) even after installing another version (either an upgrade or a downgrade).

To resolve this, we add a `-purge` flag that when passed in the uninstall command, the program data will be removed, otherwise, it will be retained.

### Testing information

Examples: To uninstall containerd

1. _WhatIf_
    ```PowerShell
    > Uninstall-Containerd -WhatIf
    
    What if: Performing the operation "Containerd will be uninstalled from 'C:\Program Files\Containerd'' and containerd service     will be stopped and unregistered" on target "COMPUTERNAME".
    ```

1. Retain the program data
    ```powershell
    > Uninstall-Containerd

    Confirm
    Are you sure you want to perform this action?
    Performing the operation "Containerd will be uninstalled from 'C:\Program Files\Containerd\bin' and containerd service will be stopped and unregistered.
    Containerd program data won't be removed. To remove program data, run 'Uninstall-Containerd' command without -Purge flag." on target "COMPUTERNAME".
    [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): Y

    Are you sure you want to uninstall Containerd?
    C:\Program Files\Containerd\bin
    [Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): Y
    WARNING: Uninstalling preinstalled Containerd at the path 'C:\Program Files\Containerd\bin'.
    Containerd will be uninstalled from 'C:\Program Files\Containerd\bin' and containerd service will be stopped and     unregistered. Containerd program data won't be removed. To remove program data, run 'Uninstall-Containerd' command without -Purge flag.
    Successfully uninstalled Containerd. 
    ```
1. Purge program data
    ```powershell
    > Uninstall-Containerd -Purge

    Confirm
    Are you sure you want to perform this action?
    Performing the operation "Containerd will be uninstalled from 'C:\Program Files\Containerd' and containerd service will be stopped and unregistered. Containerd
    program data will also be removed." on target "COMPUTERNAME".
    [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): Y

    Are you sure you want to uninstall Containerd?
    C:\Program Files\Containerd
    [Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): Y
    WARNING: Uninstalling preinstalled Containerd at the path 'C:\Program Files\Containerd'.
    Containerd will be uninstalled from 'C:\Program Files\Containerd' and containerd service will be stopped and unregistered. Containerd program data will also be removed.
    Purging Containerd program data
    WARNING: Removing Containerd registry key
    WARNING: Removing Containerd program data
    WARNING: Removing Containerd from env path
    Removing containerd in User Environment Path
    Removing containerd in System Environment Path
    Successfully uninstalled Containerd.
    ```

## TODOs not included in this PR

1. Unit tests for new functionality
2. Updating documentation for the `-purge` flag

## Checklist

As part of our commitment to engineering excellence, **before** submitting this PR, please make sure:

- [x] You've tested this code in both Desktop & Server environments and AMD & ARM64 enviroments (**functional testing**).
- [ ] You've added **unit tests** for new code.
- [ ] You've added/updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md)  and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [x] You've reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please agree to:

- [x] If changes have been made to your PR in the process of addressing comments, please make sure to test again the _final_ version in both AMD and ARM64 environments.
- [x] Validate your changes have not introduced any regressions.
