### PR TITLE
PSv5 backward compatibility for Invoke-WebRequest

### DIFF
--- a/Tests/CommonToolUtilities.Tests.ps1
+++ b/Tests/CommonToolUtilities.Tests.ps1
@@ -253,9 +253,11 @@ Describe "CommonToolUtilities.psm1" {
         It "Should throw an error if download fails" {
             $errorMessage = "Response status code does not indicate success: 404 (Not Found)."
             Mock Invoke-WebRequest { Throw $errorMessage } -ModuleName "CommonToolUtilities"
+            Mock Start-Sleep -ModuleName "CommonToolUtilities"
 
             { Get-InstallationFile -FileParameters $Script:MockFiles } | Should -Throw "Failed to download asset*"
-            $Error[1].Exception.Message | Should -BeLike "Failed to download assets for `"v2.0.0-rc.1`". Couldn`'t download `"v2.0.0-rc.1`" release assets.*"
+            Should -Invoke Invoke-WebRequest -Times 3 -Scope It -ModuleName "CommonToolUtilities"
+            $Error[1].Exception.Message | Should -BeLike "Failed to download assets for `"v2.0.0-rc.1`". Couldn`'t download `"v2.0.0-rc.1`" release assets*"
         }
     }
 


### PR DESCRIPTION
## PR description

### What does this PR do

This PR fixes a backward compatibiltu issues with PowerShell v5.1. This version's `Invoke-WebRequest` command does not have the flags `-MaximumRetryCount` and `-RetryIntervalSec`. 

### Github issue

[[BUG] [CTK v1.0.0] Install error with downloads #39](https://github.com/microsoft/containers-toolkit/issues/39)

### Relevant links

[Invoke-WebRequest PSv5.1](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-5.1)
[Invoke-WebRequest PSv7.4 and above ](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4)

## Checklist

As part of our commitment to engineering excellence, **before** submitting this PR, please make sure:

- [x] You've tested this code in both Desktop & Server environments and AMD & ARM64 enviroments (**functional testing**).
- [x] You've added **unit tests** for new code.
- [ ] You've added/updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md)  and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [x] You've reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please agree to:

- [x] If changes have been made to your PR in the process of addressing comments, please make sure to test again the _final_ version in both AMD and ARM64 environments.
- [x] Validate your changes have not introduced any regressions.
