### PR TITLE
Refactor Get-LatestToolVersion (1/4)

### DIFF
--- a/Tests/ContainerNetworkTools.Tests.ps1
+++ b/Tests/ContainerNetworkTools.Tests.ps1
@@ -31,6 +31,22 @@ Describe "ContainerNetworkTools.psm1" {
         Remove-Module -Name "$RootPath\Tests\TestData\MockClasses.psm1" -Force -ErrorAction Ignore
     }
 
+    Context "Get-WinCNILatestVersion" -Tag "Get-WinCNILatestVersion" {
+        BeforeEach {
+            Mock Get-LatestToolVersion -ModuleName 'ContainerNetworkTools'
+        }
+
+        It "Should return the latest version of Windows CNI plugin" {
+            Get-WinCNILatestVersion
+            Should -Invoke Get-LatestToolVersion -Times 1 -Scope It -ModuleName 'ContainerNetworkTools' -ParameterFilter { $Tool -eq 'wincniplugin' }
+        }
+
+        It "Should return the latest version of Cloud Native CNI plugin" {
+            Get-WinCNILatestVersion -Repo 'containernetworking/plugins'
+            Should -Invoke Get-LatestToolVersion -Times 1 -Scope It -ModuleName 'ContainerNetworkTools' -ParameterFilter { $Tool -eq 'cloudnativecni' }
+        }
+    }
+
     Context "Install-WinCNIPlugin" -Tag "Install-WinCNIPlugin" {
         BeforeAll {
             $Script:ToolName = 'WinCNIPlugin'

--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -13,7 +13,7 @@ $ModuleParentPath = Split-Path -Parent $PSScriptRoot
 Import-Module -Name "$ModuleParentPath\Private\CommonToolUtilities.psm1" -Force
 
 function Get-BuildkitLatestVersion {
-    $latestVersion = Get-LatestToolVersion -Repository "moby/buildkit"
+    $latestVersion = Get-LatestToolVersion -Tool "buildkit"
     return $latestVersion
 }
 
@@ -96,7 +96,7 @@ function Install-Buildkit {
             # Download files
             $downloadParams = @{
                 ToolName = "Buildkit"
-                Repository = "moby/buildkit"
+                Repository = "$BUILDKIT_REPO"
                 Version = $Version
                 OSArchitecture = $OSArchitecture
                 DownloadPath = $DownloadPath

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -13,7 +13,15 @@ $ModuleParentPath = Split-Path -Parent $PSScriptRoot
 Import-Module -Name "$ModuleParentPath\Private\CommonToolUtilities.psm1" -Force
 
 function Get-WinCNILatestVersion {
-    $latestVersion = Get-LatestToolVersion -Repository "microsoft/windows-container-networking"
+    param (
+        [String]$repo = "microsoft/windows-container-networking"
+    )
+    $tool = switch ($repo.ToLower()) {
+        $WINCNI_PLUGIN_REPO { "wincniplugin" }
+        $CLOUDNATIVE_CNI_REPO { "cloudnativecni" }
+        Default { Throw "Invalid repository. Supported repositories are $WINCNI_PLUGIN_REPO and $CLOUDNATIVE_CNI_REPO" }
+    }
+    $latestVersion = Get-LatestToolVersion -Tool $tool
     return $latestVersion
 }
 
@@ -80,7 +88,7 @@ function Install-WinCNIPlugin {
             # Get Windows CNI plugins version to install
             if (!$WinCNIVersion) {
                 # Get default version
-                $WinCNIVersion = Get-WinCNILatestVersion
+                $WinCNIVersion = Get-WinCNILatestVersion -Repo $SourceRepo
             }
             $WinCNIVersion = $WinCNIVersion.TrimStart('v')
             Write-Output "Downloading CNI plugin version $WinCNIVersion at $WinCNIPath"
@@ -385,8 +393,7 @@ function Install-MissingPlugin {
         $consent = ([ActionConsent](Get-Host).UI.PromptForChoice($title, $question, $choices, 1)) -eq [ActionConsent]::Yes
 
         if (-not $consent) {
-            $downloadPath = "https://github.com/microsoft/windows-container-networking"
-            Throw "Windows CNI plugins have not been installed. To install, run the command `"Install-WinCNIPlugin`" or download from $downloadPath."
+            Throw "Windows CNI plugins have not been installed. To install, run the command `"Install-WinCNIPlugin`"."
         }
     }
 

--- a/containers-toolkit/Public/ContainerdTools.psm1
+++ b/containers-toolkit/Public/ContainerdTools.psm1
@@ -13,7 +13,7 @@ Import-Module -Name "$ModuleParentPath\Private\CommonToolUtilities.psm1" -Force
 
 
 function Get-ContainerdLatestVersion {
-    $latestVersion = Get-LatestToolVersion -Repository "containerd/containerd"
+    $latestVersion = Get-LatestToolVersion -Tool "containerd"
     return $latestVersion
 }
 
@@ -85,7 +85,7 @@ function Install-Containerd {
             # Download files
             $downloadParams = @{
                 ToolName           = "Containerd"
-                Repository         = "containerd/containerd"
+                Repository         = "$CONTAINERD_REPO"
                 Version            = $version
                 OSArchitecture     = $OSArchitecture
                 DownloadPath       = $DownloadPath

--- a/containers-toolkit/Public/NerdctlTools.psm1
+++ b/containers-toolkit/Public/NerdctlTools.psm1
@@ -12,7 +12,7 @@ $ModuleParentPath = Split-Path -Parent $PSScriptRoot
 Import-Module -Name "$ModuleParentPath\Private\CommonToolUtilities.psm1" -Force
 
 function Get-NerdctlLatestVersion {
-    $latestVersion = Get-LatestToolVersion -Repository "containerd/nerdctl"
+    $latestVersion = Get-LatestToolVersion -Tool "nerdctl"
     return $latestVersion
 }
 
@@ -133,7 +133,7 @@ function Install-Nerdctl {
             # Download files
             $downloadParams = @{
                 ToolName = "nerdctl"
-                Repository = "containerd/nerdctl"
+                Repository = "$NERDCTL_REPO"
                 Version = $version
                 OSArchitecture = $OSArchitecture
                 DownloadPath = $DownloadPath


### PR DESCRIPTION
## PR description

### What does this PR do

Refactor `Get-LatestToolVersion` to take the tool name instead of the repo name. The repo names are maintained in the CommonToolUtilities.psm1 to make them reusable across the module.

## Checklist

As part of our commitment to engineering excellence, **before** submitting this PR, please make sure:

- [x] You've tested this code in both Desktop & Server environments and AMD & ARM64 enviroments (**functional testing**).
- [x] You've added **unit tests** for new code.
- [ ] You've added/updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md)  and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [x] You've reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please agree to:

- [x] If changes have been made to your PR in the process of addressing comments, please make sure to test again the _final_ version in both AMD and ARM64 environments.
- [x] Validate your changes have not introduced any regressions.
