### PR TITLE
Fix uninstall command premature exit

### DIFF
--- a/Tests/BuildkitTools.Tests.ps1
+++ b/Tests/BuildkitTools.Tests.ps1
@@ -32,8 +32,6 @@ Describe "BuildkitTools.psm1" {
         function CleanupTestDrive {
             Get-ChildItem -Path "$TestDrive" -Force -ErrorAction SilentlyContinue | `
                 Remove-Item -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
-            Get-ChildItem -Path "TestDrive:\" -Recurse -Force -ErrorAction SilentlyContinue | `
-                Remove-Item -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
     }
 
@@ -111,10 +109,10 @@ Describe "BuildkitTools.psm1" {
         }
 
         It "Should call function with user-specified values" {
-            $customPath = "TestDrive:\Downloads\buildkit-v0.2.3.windows-amd64.tar.gz"
+            $customPath = "$TestDrive\Downloads\buildkit-v0.2.3.windows-amd64.tar.gz"
             Mock Get-InstallationFile -ModuleName 'BuildkitTools' -MockWith { return $customPath }
 
-            Install-Buildkit -Version '0.2.3' -InstallPath 'TestDrive:\BuildKit' -DownloadPath 'TestDrive:\Downloads' -OSArchitecture "arm64" -Force -Confirm:$false
+            Install-Buildkit -Version '0.2.3' -InstallPath "$TestDrive\BuildKit" -DownloadPath "$TestDrive\Downloads" -OSArchitecture "arm64" -Force -Confirm:$false
 
             Should -Invoke Uninstall-Buildkit -ModuleName 'BuildkitTools' -Times 0 -Exactly -Scope It
             Should -Invoke Get-InstallationFile -ModuleName 'BuildkitTools' -ParameterFilter {
@@ -123,9 +121,9 @@ Describe "BuildkitTools.psm1" {
             }
             Should -Invoke Install-RequiredFeature -ModuleName 'BuildkitTools' -ParameterFilter {
                 $Feature -eq "Buildkit" -and
-                $InstallPath -eq 'TestDrive:\BuildKit' -and
+                $InstallPath -eq "$TestDrive\BuildKit" -and
                 $SourceFile -eq "$customPath" -and
-                $EnvPath -eq 'TestDrive:\Buildkit\bin' -and
+                $EnvPath -eq "$TestDrive\Buildkit\bin" -and
                 $cleanup -eq $true
             }
         }
@@ -310,7 +308,7 @@ Describe "BuildkitTools.psm1" {
 
     Context "Uninstall-Buildkit" -Tag "Uninstall-Buildkit" {
         BeforeAll {
-            Mock Get-DefaultInstallPath -ModuleName 'BuildkitTools' -MockWith { return 'TestDrive:\Program Files\Buildkit' }
+            Mock Get-DefaultInstallPath -ModuleName 'BuildkitTools' -MockWith { return "$TestDrive\Program Files\Buildkit" }
             Mock Test-EmptyDirectory -ModuleName 'BuildkitTools' -MockWith { return  $false }
             Mock Stop-BuildkitdService -ModuleName 'BuildkitTools'
             Mock Unregister-Buildkitd -ModuleName 'BuildkitTools'
@@ -320,7 +318,7 @@ Describe "BuildkitTools.psm1" {
         }
 
         It "Should successfully uninstall Buildkit" {
-            Uninstall-Buildkit -Path 'TestDrive:\Custom\Buildkit\' -Confirm:$false -Force
+            Uninstall-Buildkit -Path "$TestDrive\Custom\Buildkit\" -Confirm:$false -Force
 
             # Should stop and deregister the buildkitd service
             Should -Invoke Stop-BuildkitdService -Times 1 -Scope It -ModuleName "BuildkitTools"
@@ -328,7 +326,7 @@ Describe "BuildkitTools.psm1" {
 
             # Should remove buildkit dir
             Should -Invoke Remove-Item -Times 1 -Scope It -ModuleName "BuildkitTools" `
-                -ParameterFilter { $Path -eq 'TestDrive:\Custom\Buildkit\bin' }
+                -ParameterFilter { $Path -eq "$TestDrive\Custom\Buildkit\bin" }
 
             # Should not purge program data
             Should -Invoke Remove-Item -Times 0 -Scope It -ModuleName "BuildkitTools" `
@@ -343,15 +341,15 @@ Describe "BuildkitTools.psm1" {
             Uninstall-Buildkit -Confirm:$false -Force
 
             Should -Invoke Remove-Item -Times 0 -Scope It -ModuleName "BuildkitTools" `
-                -ParameterFilter { $Path -eq 'TestDrive:\Program Files\Buildkit\bin' }
+                -ParameterFilter { $Path -eq "$TestDrive\Program Files\Buildkit\bin" }
         }
 
         It "Should successfully purge program data" {
-            Uninstall-Buildkit -Path 'TestDrive:\Program Files\Buildkit' -Confirm:$false -Force -Purge
+            Uninstall-Buildkit -Path "$TestDrive\Program Files\Buildkit" -Confirm:$false -Force -Purge
 
             # Should purge program data
             Should -Invoke Remove-Item -Times 1 -Scope It -ModuleName "BuildkitTools" `
-                -ParameterFilter { $Path -eq 'TestDrive:\Program Files\Buildkit' }
+                -ParameterFilter { $Path -eq "$TestDrive\Program Files\Buildkit" }
             Should -Invoke Uninstall-ProgramFiles -Times 1 -Scope It -ModuleName "BuildkitTools" `
                 -ParameterFilter { $Path -eq "$ENV:ProgramData\Buildkit" }
             Should -Invoke Remove-FeatureFromPath -Times 1 -Scope It -ModuleName "BuildkitTools" `
@@ -360,7 +358,7 @@ Describe "BuildkitTools.psm1" {
 
         It "Should do nothing if user does not consent to uninstalling Buildkit" {
             $ENV:PESTER = $true
-            Uninstall-Buildkit -Path 'TestDrive:\Program Files\Buildkit' -Confirm:$false -Force:$false
+            Uninstall-Buildkit -Path "$TestDrive\Program Files\Buildkit" -Confirm:$false -Force:$false
 
             # Should NOT stop and deregister the buildkit service
             Should -Invoke Stop-BuildkitdService -Times 0 -Scope It -ModuleName "BuildkitTools"
@@ -373,7 +371,7 @@ Describe "BuildkitTools.psm1" {
         It "Should do nothing if buildkit is not installed at specified path" {
             Mock Test-EmptyDirectory -ModuleName 'BuildkitTools' -MockWith { return $true }
 
-            Uninstall-Buildkit -Path 'TestDrive:\Program Files\Buildkit' -Confirm:$false
+            Uninstall-Buildkit -Path "$TestDrive\Program Files\Buildkit" -Confirm:$false
 
             Should -Invoke Stop-BuildkitdService -Times 0 -Scope It -ModuleName "BuildkitTools"
             Should -Invoke Unregister-Buildkitd -Times 0 -Scope It -ModuleName "BuildkitTools"
@@ -383,7 +381,7 @@ Describe "BuildkitTools.psm1" {
         It "Should throw an error if buildkitd service stop or unregister was unsuccessful" {
             Mock Stop-BuildkitdService -ModuleName 'BuildkitTools' -MockWith { Throw 'Error' }
 
-            { Uninstall-Buildkit -Path 'TestDrive:\Program Files\Buildkit' -Confirm:$false -Force -Purge } | Should -Throw "*Could not stop or unregister buildkitd service.*"
+            { Uninstall-Buildkit -Path "$TestDrive\Program Files\Buildkit" -Confirm:$false -Force -Purge } | Should -Throw "*Could not stop or unregister buildkitd service.*"
             Should -Invoke Unregister-Buildkitd -Times 0 -Scope It -ModuleName "BuildkitTools"
             Should -Invoke Remove-Item -Times 0 -Scope It -ModuleName "BuildkitTools"
             Should -Invoke Remove-FeatureFromPath -Times 0 -Scope It -ModuleName "BuildkitTools"

--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -46,7 +46,7 @@ function Install-Buildkit {
 
         [Parameter(ParameterSetName = 'Setup')]
         [Parameter(HelpMessage = "Path to Windows CNI plugin. Defaults to `$ENV:ProgramFiles\Containerd\cni")]
-        [string]$WinCNIPath="$ENV:ProgramFiles\Containerd\cni",
+        [string]$WinCNIPath = "$ENV:ProgramFiles\Containerd\cni",
 
         [Parameter(ParameterSetName = 'Install')]
         [Parameter(ParameterSetName = 'Setup')]
@@ -140,7 +140,7 @@ function Install-Buildkit {
                 }
             }
             catch {
-                Write-Warning "Failed to registed and start Buildkitd service. $_"
+                Write-Warning "Failed to setup Buildkitd service. $_"
             }
 
             if ($showCommands) {
@@ -213,10 +213,10 @@ function Register-BuildkitdService {
     )]
     param(
         [parameter(HelpMessage = "Windows CNI plugin path. Defaults to `$ENV:ProgramFiles\Containerd\cni")]
-        [String]$WinCNIPath= "$ENV:ProgramFiles\Containerd\cni",
+        [String]$WinCNIPath = "$ENV:ProgramFiles\Containerd\cni",
 
         [parameter(HelpMessage = "Buildkit path. Defaults to `$ENV:ProgramFiles\Buildkit")]
-        [String]$BuildKitPath= "$ENV:ProgramFiles\Buildkit",
+        [String]$BuildKitPath = "$ENV:ProgramFiles\Buildkit",
 
         [parameter(HelpMessage = "Specify to start Buildkitd service after registration is complete")]
         [Switch]$Start,
@@ -285,7 +285,7 @@ function Register-BuildkitdService {
             Write-Debug "CNI conf path: $cniConfPath"
 
             # Register buildkit service
-            $command = "$buildkitdExecutable --register-service --debug --containerd-worker=true --containerd-cni-config-path=`"$cniConfPath`" --containerd-cni-binary-dir=`"$cniBinDir`" --service-name buildkitd"
+            $arguments = "--register-service --debug --containerd-worker=true --containerd-cni-config-path=`"$cniConfPath`" --containerd-cni-binary-dir=`"$cniBinDir`" --service-name buildkitd"
             if (Test-ConfFileEmpty -Path $cniConfPath) {
 
                 $consent = $force
@@ -295,7 +295,7 @@ function Register-BuildkitdService {
 
                 if ($consent) {
                     Write-Warning "Containerd conf file not found at $cniConfPath. Buildkit service will be registered without Containerd cni configurations."
-                    $command = "$buildkitdExecutable --register-service --debug --containerd-worker=true --service-name buildkitd"
+                    $arguments = "--register-service --debug --containerd-worker=true --service-name buildkitd"
                 }
                 else {
                     Write-Error "Failed to register buildkit service. Containerd conf file not found at $cniConfPath.`n`t1. Ensure that the required CNI plugins are installed or you can install them using 'Install-WinCNIPlugin'.`n`t2. Create the file to resolve this issue .`n`t3. Rerun this command  'Register-BuildkitdService'"
@@ -303,12 +303,8 @@ function Register-BuildkitdService {
                 }
             }
 
-            # remove the executable extension from the command
-            $escapedPath = [regex]::Escape($buildkitdExecutable)
-            $arguments = ($command -replace "$escapedPath", "").Trim()
-
             # Register the service
-            $output = Invoke-ExecutableCommand -Executable $buildkitdExecutable -Arguments $arguments
+            $output = Invoke-ExecutableCommand -Executable "$buildkitdExecutable" -Arguments $arguments
             if ($output.ExitCode -ne 0) {
                 Throw "Failed to register buildkitd service. $($output.StandardError.ReadToEnd())"
             }
@@ -386,10 +382,10 @@ function Uninstall-Buildkit {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-            if (Test-EmptyDirectory -Path "$path") {
-                Write-Output "$tool does not exist at '$Path' or the directory is empty"
-                return
-            }
+            # if (Test-EmptyDirectory -Path "$path") {
+            #     Write-Output "$tool does not exist at '$Path' or the directory is empty"
+            #     return
+            # }
 
             $consent = $force
             if (!$ENV:PESTER) {
@@ -426,23 +422,20 @@ function Uninstall-BuildkitHelper {
         [Switch] $Purge
     )
 
-    if (Test-EmptyDirectory -Path "$Path") {
-        Write-Error "Buildkit does not exist at '$Path' or the directory is empty."
-        return
-    }
-
-    try {
-        if (Test-ServiceRegistered -Service 'Buildkitd') {
-            Stop-BuildkitdService
-            Unregister-Buildkitd -BuildkitPath "$Path"
+    if (-not (Test-EmptyDirectory -Path "$Path")) {
+        try {
+            if (Test-ServiceRegistered -Service 'Buildkitd') {
+                Stop-BuildkitdService
+                Unregister-Buildkitd -BuildkitPath "$Path"
+            }
         }
-    }
-    catch {
-        Throw "Could not stop or unregister buildkitd service. $_"
-    }
+        catch {
+            Throw "Could not stop or unregister buildkitd service. $_"
+        }
 
-    # Remove the folder where buildkit is installed and related folders
-    Remove-Item -Path "$Path" -Recurse -Force
+        # Remove the folder where buildkit is installed and related folders
+        Remove-Item -Path "$Path" -Recurse -Force
+    }
 
     if ($Purge) {
         Write-Output "Purging Buildkit program data"
@@ -494,10 +487,10 @@ function Unregister-Buildkitd($buildkitPath) {
     }
 
     # Unregister buildkit service
-    $buildkitdExecutable = "$buildkitPath\bin\buildkitd.exe"
+    $buildkitdExecutable = (Get-ChildItem -Path "$buildkitPath" -Recurse -Filter "buildkitd.exe").FullName | Select-Object -First 1
 
-    Write-Debug "Buildkitd path: $buildkitdExecutable "
-    $output = Invoke-ExecutableCommand -Executable $buildkitdExecutable -Arguments "--unregister-service"
+    Write-Debug "Buildkitd path: '$buildkitdExecutable'"
+    $output = Invoke-ExecutableCommand -Executable "$buildkitdExecutable" -Arguments "--unregister-service"
     if ($output.ExitCode -ne 0) {
         Throw "Could not unregister buildkitd service. $($output.StandardError.ReadToEnd())"
     }

--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -140,7 +140,7 @@ function Install-Buildkit {
                 }
             }
             catch {
-                Write-Warning "Failed to setup Buildkitd service. $_"
+                Write-Warning "Failed to set up Buildkitd service. $_"
             }
 
             if ($showCommands) {

--- a/containers-toolkit/Public/BuildkitTools.psm1
+++ b/containers-toolkit/Public/BuildkitTools.psm1
@@ -382,11 +382,6 @@ function Uninstall-Buildkit {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-            # if (Test-EmptyDirectory -Path "$path") {
-            #     Write-Output "$tool does not exist at '$Path' or the directory is empty"
-            #     return
-            # }
-
             $consent = $force
             if (!$ENV:PESTER) {
                 $consent = $force -or $PSCmdlet.ShouldContinue($env:COMPUTERNAME, "Are you sure you want to uninstall Buildkit from '$path'?")

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -380,10 +380,10 @@ function Import-HNSModule {
         return
     }
 
-    $ModuleName = 'HNS'
-    # https://www.powershellgallery.com/packages/HNS/0.2.4
-    if (Get-Module -ListAvailable -Name $ModuleName) {
-        Get-Module -ListAvailable -Name "$ModuleName" | Import-Module -DisableNameChecking -Force:$force
+    # Check and import HostNetworkingService module
+    $hnsModule = Get-Module -ListAvailable -Name 'HNS' -ErrorAction SilentlyContinue
+    if ($hnsModule) {
+        $hnsModule | Import-Module -DisableNameChecking -Force:$force
         return
     }
 

--- a/containers-toolkit/Public/ContainerNetworkTools.psm1
+++ b/containers-toolkit/Public/ContainerNetworkTools.psm1
@@ -383,7 +383,7 @@ function Import-HNSModule {
     $ModuleName = 'HNS'
     # https://www.powershellgallery.com/packages/HNS/0.2.4
     if (Get-Module -ListAvailable -Name $ModuleName) {
-        Import-Module -Name $ModuleName -DisableNameChecking -Force:$Force
+        Get-Module -ListAvailable -Name "$ModuleName" | Import-Module -DisableNameChecking -Force:$force
         return
     }
 

--- a/containers-toolkit/Public/ContainerdTools.psm1
+++ b/containers-toolkit/Public/ContainerdTools.psm1
@@ -331,11 +331,6 @@ function Uninstall-Containerd {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-            # if (Test-EmptyDirectory -Path $path) {
-            #     Write-Output "$tool does not exist at $Path or the directory is empty"
-            #     return
-            # }
-
             $consent = $force
             if (!$ENV:PESTER) {
                 $consent = $force -or $PSCmdlet.ShouldContinue($Path, 'Are you sure you want to uninstall Containerd?')
@@ -373,9 +368,6 @@ function Uninstall-ContainerdHelper {
     )
 
     if (-not (Test-EmptyDirectory -Path "$Path")) {
-        # Write-Error "Containerd does not exist at $Path or the directory is empty."
-        # return
-
         try {
             if (Test-ServiceRegistered -Service 'containerd') {
                 Stop-ContainerdService

--- a/containers-toolkit/Public/NerdctlTools.psm1
+++ b/containers-toolkit/Public/NerdctlTools.psm1
@@ -224,12 +224,6 @@ function Uninstall-Nerdctl {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-
-            # if (Test-EmptyDirectory -Path "$path") {
-            #     Write-Output "$tool does not exist at '$Path' or the directory is empty"
-            #     return
-            # }
-
             $consent = $force
             if (!$ENV:PESTER) {
                 $consent = $force -or $PSCmdlet.ShouldContinue($Path, 'Are you sure you want to uninstall nerdctl?')
@@ -279,10 +273,7 @@ function Uninstall-NerdctlHelper {
         [Switch] $Purge
     )
 
-    if (Test-EmptyDirectory -Path "$Path") {
-        # Write-Error "nerdctl does not exist at '$Path' or the directory is empty."
-        # return
-
+    if (-not (Test-EmptyDirectory -Path "$Path")) {
         # Remove the folder where nerdctl is installed and related folders
         Remove-Item -Path "$Path" -Recurse -Force
     }

--- a/containers-toolkit/Public/NerdctlTools.psm1
+++ b/containers-toolkit/Public/NerdctlTools.psm1
@@ -224,10 +224,11 @@ function Uninstall-Nerdctl {
 
     process {
         if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, $WhatIfMessage)) {
-            if (Test-EmptyDirectory -Path "$path") {
-                Write-Output "$tool does not exist at '$Path' or the directory is empty"
-                return
-            }
+
+            # if (Test-EmptyDirectory -Path "$path") {
+            #     Write-Output "$tool does not exist at '$Path' or the directory is empty"
+            #     return
+            # }
 
             $consent = $force
             if (!$ENV:PESTER) {
@@ -239,11 +240,15 @@ function Uninstall-Nerdctl {
                 return
             }
 
+            $executablePath = (Get-ChildItem -Path "$path" -Filter "nerdctl.exe" -Recurse | Select-Object -First 1).FullName
+            Write-Debug "nerdctl executable path: $executablePath"
+
             Write-Warning "Uninstalling preinstalled $tool at the path '$path'.`n$WhatIfMessage"
             try {
-                if ($Purge) {
+                if ($executablePath -and $Purge) {
                     # Remove all unused images, not just dangling ones
-                    $cmdOutput = Invoke-ExecutableCommand -Executable "$path\nerdctl.exe" -Arguments "system prune --all"
+                    Write-Debug "Pruning all unused images..."
+                    $cmdOutput = Invoke-ExecutableCommand -Executable "$executablePath" -Arguments "system prune --all --force"
                     if ($cmdOutput.ExitCode -ne 0) {
                         Write-Warning "Couldn't prune images. $($cmdOutput.StandardError.ReadToEnd())"
                     }
@@ -275,12 +280,12 @@ function Uninstall-NerdctlHelper {
     )
 
     if (Test-EmptyDirectory -Path "$Path") {
-        Write-Error "nerdctl does not exist at '$Path' or the directory is empty."
-        return
-    }
+        # Write-Error "nerdctl does not exist at '$Path' or the directory is empty."
+        # return
 
-    # Remove the folder where nerdctl is installed and related folders
-    Remove-Item -Path "$Path" -Recurse -Force
+        # Remove the folder where nerdctl is installed and related folders
+        Remove-Item -Path "$Path" -Recurse -Force
+    }
 
     if ($Purge) {
         Write-Output "Purging nerdctl program data"


### PR DESCRIPTION
## PR Description

This PR ensures uninstall routines no longer exit prematurely on empty directories.
 
Current implementation:

https://github.com/microsoft/containers-toolkit/blob/216fb37e5b02399090a023f95610d003adc72374/containers-toolkit/Public/ContainerdTools.psm1#L334-L337

This causes the command to exit prematurely, even when the `-purge` flag is passed.

Additionl tasks:

1. Properly quotes executable paths for command invocations.
2. Refactors HNS module import logic
3. Use `$TestDrive` instead of `TestDtivr:\` in Buildkit Tests
4. Update unit tests

## Checklist

As part of our commitment to engineering excellence, **before** submitting this PR, please ensure:

- [ ] You have tested this code in both Desktop and Server environments, as well as AMD64 and ARM64 environments (**functional testing**).
- [ ] You have added **unit tests** for new code.
- [ ] You have added or updated documentation in the [cmdlet docs](../docs/About/), [command-reference.md](../docs/command-reference.md), and the [modules help files](../containers-toolkit/en-US/containers-toolkit-help.xml).
- [ ] You have reviewed the PR/code best practices defined in the [CONTRIBUTING.md](../CONTRIBUTING.md).

In addition, **after** this PR has been reviewed, please ensure:

- [ ] If you make changes while addressing review comments, you test the _final_ version again in both AMD64 and ARM64 environments.
- [ ] You validate that your changes have not introduced any regressions.
